### PR TITLE
Fix boolean option parsing

### DIFF
--- a/lib/simple_scripting/argv.rb
+++ b/lib/simple_scripting/argv.rb
@@ -243,7 +243,8 @@ module SimpleScripting
       end
 
       parser_opts.on(*param_definition) do |value|
-        result[key] = value || true
+        raise "Unexpected (nil; likely programmatic error) value for param definition #{param_definition}" if value.nil?
+        result[key] = value
       end
     end
 

--- a/spec/simple_scripting/argv_spec.rb
+++ b/spec/simple_scripting/argv_spec.rb
@@ -111,6 +111,48 @@ module SimpleScripting
         expect(actual_result).to eql(expected_result)
       end
 
+      context "booleans" do
+        VALID_BOOLS = {
+          'false' => false,
+          'true'  => true,
+        }
+
+        INVALID_BOOLS = %w[falx FALSE TRUE]
+
+        VALID_BOOLS.each do |user_value, decoded_value|
+          it "should decode a #{decoded_value} value" do
+            decoder_params = [
+              ["-b", "--mybool VAL", TrueClass],
+              output:     output_buffer,
+              arguments: ['--mybool', 'false']
+            ]
+
+            actual_result = described_class.decode(*decoder_params)
+
+            expected_result = {
+              mybool: false
+            }
+
+            expect(actual_result).to eql(expected_result)
+          end
+        end
+
+        INVALID_BOOLS.each do |value|
+          it "should raise an error on invalid bool #{value.inspect}" do
+            decoder_params = [
+              ["-b", "--mybool VAL", TrueClass],
+              output:       output_buffer,
+              arguments:    ['--mybool', value],
+              raise_errors: true,
+            ]
+
+            expect {
+              described_class.decode(*decoder_params)
+            }.to raise_error(OptionParser::InvalidArgument)
+          end
+        end
+      end
+
       context "multiple optional arguments" do
 
         let(:decoder_params) {[


### PR DESCRIPTION
It's not entirely clear what the code was trying to accomplish. For sure, it prevented boolean definitions with `false` value.
    
The new code assumes that nil values are impossible, and that any other value is in the final form.

Also added test coverage.