### PR TITLE
Make SimpleCov compatible with Ruby 3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         ruby-version: [head, 3.0, 2.7, 2.6, 2.5, 2.4, 2.3]
+      fail-fast: false
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
     - uses: actions/checkout@v3

--- a/.simplecov
+++ b/.simplecov
@@ -3,6 +3,4 @@ require 'coveralls'
 
 SimpleCov.formatter = Coveralls::SimpleCov::Formatter
 
-SimpleCov.start do
-   add_filter '/spec/'
-end
+SimpleCov.add_filter '/spec/'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'coveralls', '~> 0.8.21', require: false
+  gem 'coveralls', '~> 0.8.23', require: false
 end
 
 group :tools do


### PR DESCRIPTION
Not clear (without investigating) why this fails on Ruby 3, but it doesn't really matter. Fix copied from https://github.com/sul-dlss/moab-versioning/pull/192.

Other minor changes:

- Updated Coveralls base version
- Disabled fail-fast for CI