### PR TITLE
Complete test suite to 100% coverage

### DIFF
--- a/spec/simple_scripting/argv_spec.rb
+++ b/spec/simple_scripting/argv_spec.rb
@@ -522,5 +522,26 @@ module SimpleScripting
         }.to raise_error(Argv::ArgumentError, "Too many arguments")
       end
     end # describe 'No definitions given'
+
+    describe 'Definition/options handling' do
+      it "should work when no options hash is passed, reading ARGV" do
+        original_argv = ARGV.dup
+        ARGV.replace(['m_arg'])
+
+        begin
+          actual_result = described_class.decode('mandatory')
+
+          expect(actual_result).to eql(mandatory: 'm_arg')
+        ensure
+          ARGV.replace(original_argv)
+        end
+      end
+
+      it "should raise on an unrecognized param definition" do
+        expect {
+          described_class.decode(123, arguments: [], output: output_buffer)
+        }.to raise_error(RuntimeError, "Unrecognized value: 123")
+      end
+    end # describe 'Definition/options handling'
   end # describe Argv
 end # module SimpleScripting

--- a/spec/simple_scripting/configuration_spec.rb
+++ b/spec/simple_scripting/configuration_spec.rb
@@ -70,4 +70,22 @@ g2_key=bang
       File.delete(temp_config_file)
     end
   end
+
+  it "should derive the default config file from the program name, when none is given" do
+    Dir.mktmpdir do |home|
+      original_home = ENV['HOME']
+      original_prog = $PROGRAM_NAME
+      ENV['HOME'] = home
+      $PROGRAM_NAME = 'my_test_prog.rb'
+
+      begin
+        described_class.load
+
+        expect(File).to exist(File.join(home, '.my_test_prog'))
+      ensure
+        ENV['HOME'] = original_home
+        $PROGRAM_NAME = original_prog
+      end
+    end
+  end
 end # describe SimpleScripting::Configuration


### PR DESCRIPTION
## Summary

Bring line coverage to 100% by adding characterization tests for the previously-uncovered paths:

- `argv.rb`: the options-less `decode` path (reads `ARGV`) and the error raised on a non-Array/String param definition
- `configuration.rb`: the default config-file derivation from `$PROGRAM_NAME` when `load` is called with no `config_file`

## Test plan

- `bundle exec rspec` → 69 examples, 0 failures; SimpleCov reports `Line Coverage: 100.0% (248/248)`.
- (4 pre-existing pending tests remain in the tab-completion spec, unrelated to coverage.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
