### PR TITLE
Remove unused parameters from private argument/completion helpers

### DIFF
--- a/lib/simple_scripting/argv.rb
+++ b/lib/simple_scripting/argv.rb
@@ -205,9 +205,9 @@ module SimpleScripting
       arg_definitions.each do |arg_name, arg_is_mandatory|
         if arg_name.to_s.start_with?('*')
           arg_name = arg_name.to_s[1..-1].to_sym
-          process_varargs!(arg_values, result, commands_stack, arg_name, arg_is_mandatory)
+          process_varargs!(arg_values, result, arg_name, arg_is_mandatory)
         else
-          process_regular_argument!(arg_values, result, commands_stack, arg_name, arg_is_mandatory)
+          process_regular_argument!(arg_values, result, arg_name, arg_is_mandatory)
         end
       end
 
@@ -253,14 +253,14 @@ module SimpleScripting
       end
     end
 
-    def process_varargs!(arg_values, result, commands_stack, arg_name, arg_is_mandatory)
+    def process_varargs!(arg_values, result, arg_name, arg_is_mandatory)
       raise ArgumentError.new("Missing mandatory argument(s)") if arg_is_mandatory && arg_values.empty?
 
       result[arg_name] = arg_values.dup
       arg_values.clear
     end
 
-    def process_regular_argument!(arg_values, result, commands_stack, arg_name, arg_is_mandatory)
+    def process_regular_argument!(arg_values, result, arg_name, arg_is_mandatory)
       if arg_values.empty?
         if arg_is_mandatory
           raise ArgumentError.new("Missing mandatory argument(s)")

--- a/lib/simple_scripting/tab_completion.rb
+++ b/lib/simple_scripting/tab_completion.rb
@@ -29,7 +29,7 @@ module SimpleScripting
       commandline_processor = CommandlineProcessor.process_commandline(source_commandline, cursor_position, @switches_definition)
 
       if commandline_processor.completing_an_option?
-        complete_option(commandline_processor, execution_target)
+        complete_option(commandline_processor)
       elsif commandline_processor.parsing_error?
         return
       else # completing_a_value?
@@ -43,7 +43,7 @@ module SimpleScripting
     # Completion!
     #############################################
 
-    def complete_option(commandline_processor, execution_target)
+    def complete_option(commandline_processor)
       all_switches = @switches_definition.select { |definition| definition.is_a?(Array) }.map { |definition| definition[1][/^--\S+/] }
 
       matching_switches = all_switches.select { |switch| switch.start_with?(commandline_processor.completing_word_prefix) }


### PR DESCRIPTION
## Summary

Small dead-code cleanup: three private helpers accepted parameters they never used.

- `Argv#process_varargs!` and `Argv#process_regular_argument!` took `commands_stack` but never referenced it.
- `TabCompletion#complete_option` took `execution_target` but never referenced it.

Drops the unused parameters and updates the call sites. No behavior change.

## Notes

- Private methods only; public API unchanged.
- `69 examples, 0 failures, 4 pending`; line coverage 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
